### PR TITLE
feat(locations): add location microdata (#17)

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -494,3 +494,8 @@ audio::-webkit-media-controls-enclosure {
 audio::-webkit-media-controls-panel {
   background-color: var(--link-color);
 }
+
+/* Pin emoji for wrapped addresses */
+.pinned-address address::before {
+  content: "📍 ";
+}

--- a/layouts/partials/event-main-content.html
+++ b/layouts/partials/event-main-content.html
@@ -46,12 +46,19 @@
     {{ with $page.GetTerms "locations" }}
         {{ range . }}
             {{ $locationName = .Title }}
-            {{ $locationAddress = .Params.address }}
-            {{ $locationCity = .Params.city }}
-            {{ $locationState = .Params.state }}
-            {{ $locationZip = .Params.zip }}
             {{ $locationLink = .RelPermalink }}
-            {{ $hasLocationTaxonomy = true }}
+            {{ if $locationName }}
+            <p>🏛️ <span itemprop="name">
+                {{ if $hasLocationTaxonomy }}
+                    <a href="{{ $locationLink }}">{{ $locationName }}</a>
+                {{ else }}
+                    {{ $locationName }}
+                {{ end }}
+            </span></p>
+            {{ end }}
+            <span class="pinned-address">
+                {{ partial "postal-address.html" . }}
+            </span>
         {{ end }}
     {{ else }}
         {{ with $page.Params.location }}
@@ -61,21 +68,27 @@
         {{ $locationCity = $page.Params.city }}
         {{ $locationState = $page.Params.state }}
         {{ $locationZip = $page.Params.zip }}
-    {{ end }}
-    
-    {{ if $locationName }}
-    <p>🏛️ <span itemprop="name">
-        {{ if $hasLocationTaxonomy }}
-            <a href="{{ $locationLink }}">{{ $locationName }}</a>
-        {{ else }}
-            {{ $locationName }}
+        {{ if $locationName }}
+        <p>🏛️ <span itemprop="name">
+            {{ if $hasLocationTaxonomy }}
+                <a href="{{ $locationLink }}">{{ $locationName }}</a>
+            {{ else }}
+                {{ $locationName }}
+            {{ end }}
+        </span></p>
         {{ end }}
-    </span></p>
-    {{ end }}
-    
-    {{ if and $locationAddress $locationCity $locationState $locationZip }}
-    {{ $address := printf "%s, %s, %s %s" $locationAddress $locationCity $locationState $locationZip }}
-    <p>📍 <a href="https://www.google.com/maps/search/?api=1&query={{ $address | urlquery }}" target="_blank" itemprop="address">{{ $address }}</a></p>
+        
+        {{ if and $locationAddress $locationCity $locationState $locationZip }}
+        {{ $address := printf "%s, %s, %s %s" $locationAddress $locationCity $locationState $locationZip }}
+        <p>📍
+          <a href="https://www.google.com/maps/search/?api=1&query={{ $address | urlquery }}" target="_blank" itemprop="address">
+            <span itemprop="streetAddress">{{ $locationAddress }}</span>, 
+            <span itemprop="addressLocality">{{ $locationCity }}</span>, 
+            <span itemprop="addressRegion">{{ $locationState }}</span> 
+            <span itemprop="postalCode">{{ $locationZip }}</span>
+          </a>
+        </p>
+        {{ end }}
     {{ end }}
 </span>
 {{ with $page.Params.link }}

--- a/layouts/partials/postal-address.html
+++ b/layouts/partials/postal-address.html
@@ -1,0 +1,52 @@
+{{ define "address-content" }}
+  {{ with .address }}
+  <span itemprop="streetAddress">{{ . }}</span>,
+  {{ end }}
+  {{ with .city }}
+  <span itemprop="addressLocality">{{ . }}</span>,
+  {{ end }}
+  {{ with .state }}
+  <span itemprop="addressRegion">{{ . }}</span>
+  {{ end }}
+  {{ with .zip }}
+  <span itemprop="postalCode">{{ . }}</span>
+  {{ end }}
+{{ end }}
+
+{{ define "address-wrapper" }}
+  {{ if .href }}
+    <a href="{{ .href }}" target="_blank" itemprop="url">
+      {{ template "address-content" .address }}
+    </a>
+  {{ else }}
+    {{ template "address-content" .address }}
+  {{ end }}
+{{ end }}
+
+{{ $address := .Params.address }}
+{{ if not (reflect.IsMap $address) }}
+{{ if or (isset .Params "address") (isset .Params "city") (isset .Params "state") (isset .Params "zip" ) }}
+{{ $address = dict "address" .Params.address "city" .Params.city "state" .Params.state "zip" .Params.zip }}
+{{ if isset .Params "map" }}
+{{ $address = merge $address (dict "map" .Params.map) }}
+{{ end }}
+{{ else }}
+{{ $address = "" }}
+{{ end }}
+{{ end }}
+
+{{ with $address }}
+<address itemscope itemtype="http://schema.org/PostalAddress">
+  {{ $href := "" }}
+  {{ if or (not (isset . "map")) (eq .map "googlemaps") }}
+    {{ $addressParts := slice }}
+    {{ with .address }}{{ $addressParts = $addressParts | append . }}{{ end }}
+    {{ with .city }}{{ $addressParts = $addressParts | append . }}{{ end }}
+    {{ with .state }}{{ $addressParts = $addressParts | append . }}{{ end }}
+    {{ with .zip }}{{ $addressParts = $addressParts | append . }}{{ end }}
+    {{ $mapAddress := delimit $addressParts ", " }}
+    {{ $href = printf "https://www.google.com/maps/search/?api=1&query=%s" ($mapAddress | urlquery) }}
+  {{ end }}
+  {{ template "address-wrapper" (dict "href" $href "address" $address) }}
+</address>
+{{ end }}

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "test:ui": "playwright test --ui"
   },
   "devDependencies": {
-     "@playwright/test": "^1.53.1",
-     "get-port": "^7.1.0",
-     "@types/node": "24.0.3",
-     "typescript": "^5.7.3"
+    "@playwright/test": "^1.53.1",
+    "@types/json-to-pretty-yaml": "^1.2.1",
+    "@types/node": "24.0.3",
+    "get-port": "^7.1.0",
+    "json-to-pretty-yaml": "^1.2.2",
+    "typescript": "^5.7.3"
   }
 }

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -5,7 +5,8 @@ import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import getPort from 'get-port';
 import { test as base } from '@playwright/test';
-import { PaginatedPageFixture } from './fixtures/pagination.js';
+import { PaginatedPageFixture } from './fixtures/pagination';
+import { PostalAddressPageFixture } from './fixtures/postal-address';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -43,6 +44,7 @@ export interface ServerFixture {
 export interface TestFixtures {
   server: ServerFixture;
   paginatedPage: PaginatedPageFixture;
+  postalAddressPage: PostalAddressPageFixture;
 }
 
 // Global cleanup tracking
@@ -72,6 +74,11 @@ export const test = base.extend<TestFixtures>({
   paginatedPage: async ({ page, server }, use) => {
     const paginatedPage = new PaginatedPageFixture(page, server);
     await use(paginatedPage);
+  },
+
+  postalAddressPage: async ({ page, server }, use) => {
+    const postalAddressPage = new PostalAddressPageFixture(page, server);
+    await use(postalAddressPage);
   },
 });
 

--- a/tests/fixtures/postal-address.ts
+++ b/tests/fixtures/postal-address.ts
@@ -1,0 +1,114 @@
+import { Page } from '@playwright/test';
+import { ServerFixture } from '../fixtures.js';
+import YAML from 'json-to-pretty-yaml';
+
+export interface PostalAddressOptions {
+  streetAddress?: string;
+  addressLocality?: string;
+  addressRegion?: string;
+  postalCode?: string;
+  map?: string;
+}
+
+export class PostalAddressPageFixture {
+  private baseURL = '';
+
+  constructor(
+    private page: Page,
+    private server: ServerFixture,
+  ) {}
+
+  async createWithAddress(address?: PostalAddressOptions): Promise<void> {
+    // Generate Hugo site configuration
+    const hugoConfig = `
+baseURL = "http://localhost"
+title = "Test Site"
+languageCode = "en-us"
+`;
+    // Generate content file with postal address partial
+    // Conditionally render address if address is provided
+    const frontMatter = YAML.stringify({
+      title: 'Test Postal Address',
+      date: '2024-01-01T10:00:00Z',
+      address: address?.streetAddress,
+      city: address?.addressLocality,
+      state: address?.addressRegion,
+      zip: address?.postalCode,
+      map: address?.map,
+    });
+    const contentFile = `---
+${frontMatter}
+---`;
+
+    console.log('Generated front matter:\n', frontMatter);
+
+    // Create test section template
+    const postalAddressTemplate = `{{ define "main" }}
+<div class="container">
+    <h1>{{ .Title }}</h1>
+    {{ partial "postal-address.html" . }}
+</div>
+{{ end }}`;
+
+    // Create the site on the server
+    const { baseURL } = await this.server.start({
+      hugoConfig,
+      contentFiles: {
+        'postal-address.md': contentFile,
+      },
+      layoutFiles: {
+        '_default/single.html': postalAddressTemplate,
+      },
+    });
+
+    this.baseURL = baseURL;
+  }
+
+  goto() {
+    return this.page.goto(this.baseURL + '/postal-address/');
+  }
+
+  getAddressElement() {
+    return this.page.locator('address[itemscope][itemtype="http://schema.org/PostalAddress"]');
+  }
+
+  getStreetAddressElement() {
+    return this.getAddressElement().locator('span[itemprop="streetAddress"]');
+  }
+
+  getStreetAddressElementContains(streetAddress: string) {
+    return this.getAddressElement().locator(`span[itemprop="streetAddress"]:has-text("${streetAddress}")`);
+  }
+
+  getAddressLocalityElement() {
+    return this.getAddressElement().locator('span[itemprop="addressLocality"]');
+  }
+
+  getAddressLocalityElementContains(locality: string) {
+    return this.getAddressElement().locator(`span[itemprop="addressLocality"]:has-text("${locality}")`);
+  }
+
+  getAddressRegionElement() {
+    return this.getAddressElement().locator('span[itemprop="addressRegion"]');
+  }
+
+  getAddressRegionElementContains(region: string) {
+    return this.getAddressElement().locator(`span[itemprop="addressRegion"]:has-text("${region}")`);
+  }
+
+  getPostalCodeElement() {
+    return this.getAddressElement().locator('span[itemprop="postalCode"]');
+  }
+
+  getPostalCodeElementContains(postalCode: string) {
+    return this.getAddressElement().locator(`span[itemprop="postalCode"]:has-text("${postalCode}")`);
+  }
+
+  getLinkElementHrefContains(substring: string) {
+    return this.getAddressElement().locator(`a[itemprop="url"][href*="${substring}"]`);
+  }
+
+  getLinkElement() {
+    return this.getAddressElement().locator('a[itemprop="url"]');
+  }
+}

--- a/tests/postal-address.test.ts
+++ b/tests/postal-address.test.ts
@@ -1,0 +1,200 @@
+import { expect } from '@playwright/test';
+import { test } from './fixtures.js';
+
+test.describe('Postal Address', () => {
+  test('should render post address microdata', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial
+    await postalAddressPage.createWithAddress({
+      streetAddress: '123 Main St',
+      addressLocality: 'Springfield',
+      addressRegion: 'IL',
+      postalCode: '62701',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should see the postal address microdata item
+    const addressElement = postalAddressPage.getAddressElement();
+    await expect(addressElement).toBeVisible();
+  });
+
+  test('should render postal address microdate with streetAddress property', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial
+    await postalAddressPage.createWithAddress({
+      streetAddress: '456 Elm St',
+      addressLocality: 'Metropolis',
+      addressRegion: 'NY',
+      postalCode: '10001',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should see the streetAddress property in the microdata
+    const addressElement = postalAddressPage.getStreetAddressElementContains('456 Elm St');
+    await expect(addressElement).toBeVisible();
+  });
+
+  test('should render postal address microdata with addressLocality property', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial
+    await postalAddressPage.createWithAddress({
+      streetAddress: '789 Oak St',
+      addressLocality: 'Gotham',
+      addressRegion: 'NJ',
+      postalCode: '07097',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should see the addressLocality property in the microdata
+    const addressElement = postalAddressPage.getAddressLocalityElementContains('Gotham');
+    await expect(addressElement).toBeVisible();
+  });
+
+  test('should render postal address microdata with addressRegion property', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial
+    await postalAddressPage.createWithAddress({
+      streetAddress: '101 Pine St',
+      addressLocality: 'Star City',
+      addressRegion: 'CA',
+      postalCode: '90210',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should see the addressRegion property in the microdata
+    const addressElement = postalAddressPage.getAddressRegionElementContains('CA');
+    await expect(addressElement).toBeVisible();
+  });
+
+  test('should render postal address microdata with postalCode property', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial
+    await postalAddressPage.createWithAddress({
+      streetAddress: '202 Maple St',
+      addressLocality: 'Central City',
+      addressRegion: 'MO',
+      postalCode: '64101',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should see the postalCode property in the microdata
+    const addressElement = postalAddressPage.getPostalCodeElementContains('64101');
+    await expect(addressElement).toBeVisible();
+  });
+
+  test('should not render address if there is no address data', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial but no address data
+    await postalAddressPage.createWithAddress();
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should not see the postal address microdata item
+    const addressElement = postalAddressPage.getAddressElement();
+    await expect(addressElement).toHaveCount(0);
+  });
+
+  test('should not render streetAddress if streetAddress is missing', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial but no streetAddress
+    await postalAddressPage.createWithAddress({
+      addressLocality: 'Springfield',
+      addressRegion: 'IL',
+      postalCode: '62701',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should not see the streetAddress property in the microdata
+    const addressElement = postalAddressPage.getStreetAddressElement();
+    await expect(addressElement).toHaveCount(0);
+  });
+
+  test('should not render addressLocality if addressLocality is missing', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial but no addressLocality
+    await postalAddressPage.createWithAddress({
+      streetAddress: '123 Main St',
+      addressRegion: 'IL',
+      postalCode: '62701',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should not see the addressLocality property in the microdata
+    const addressElement = postalAddressPage.getAddressLocalityElement();
+    await expect(addressElement).toHaveCount(0);
+  });
+
+  test('should not render addressRegion if addressRegion is missing', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial but no addressRegion
+    await postalAddressPage.createWithAddress({
+      streetAddress: '123 Main St',
+      addressLocality: 'Springfield',
+      postalCode: '62701',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should not see the addressRegion property in the microdata
+    const addressElement = postalAddressPage.getAddressRegionElement();
+    await expect(addressElement).toHaveCount(0);
+  });
+
+  test('should not render postalCode if postalCode is missing', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial but no postalCode
+    await postalAddressPage.createWithAddress({
+      streetAddress: '123 Main St',
+      addressLocality: 'Springfield',
+      addressRegion: 'IL',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should not see the postalCode property in the microdata
+    const addressElement = postalAddressPage.getPostalCodeElement();
+    await expect(addressElement).toHaveCount(0);
+  });
+
+  test('should render address link to Google Maps when configured', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial with Google Maps link
+    await postalAddressPage.createWithAddress({
+      streetAddress: '1600 Amphitheatre Parkway',
+      addressLocality: 'Mountain View',
+      addressRegion: 'CA',
+      postalCode: '94043',
+      map: 'googlemaps',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should see the address wrapped in a link to Google Maps
+    const linkElement = postalAddressPage.getLinkElementHrefContains('https://www.google.com/maps/search/?api=1&query=1600+Amphitheatre+Parkway%2C+Mountain+View%2C+CA%2C+94043');
+    await expect(linkElement).toBeVisible();
+  });
+
+  test('should not render address link when link option is not set', async ({ postalAddressPage }) => {
+    // GIVEN a page that uses the postal address partial without link option
+    await postalAddressPage.createWithAddress({
+      streetAddress: '1600 Amphitheatre Parkway',
+      addressLocality: 'Mountain View',
+      addressRegion: 'CA',
+      postalCode: '94043',
+    });
+
+    // WHEN we navigate to that page
+    await postalAddressPage.goto();
+
+    // THEN we should not see the address wrapped in a link
+    const linkElement = postalAddressPage.getLinkElement();
+    await expect(linkElement).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Resolves #17 

This pull request introduces enhancements to address rendering and testing in the codebase. It adds support for rendering postal address microdata using a reusable partial, updates the event layout to integrate the new partial, and introduces comprehensive tests for postal address functionality. Additionally, it updates dependencies and fixtures to support these changes.

### Address rendering updates:
* **New postal address partial**: Added `postal-address.html` partial to render postal address microdata with schema.org compatibility. It supports optional fields like street address, city, state, zip, and a Google Maps link. (`layouts/partials/postal-address.html`, [layouts/partials/postal-address.htmlR1-R52](diffhunk://#diff-d85e6d9c44fa11a5eb7343cdd1e5ee9150b533869eeac98a0a7518bc05257550R1-R52))
* **Event layout integration**: Updated `event-main-content.html` to use the new postal address partial and improved layout for address display. (`layouts/partials/event-main-content.html`, [[1]](diffhunk://#diff-9b03529f8909aa492e1459d80fb3e822510ad1f6ac41a8c51bd021a2af8f3fc9L49-R61) [[2]](diffhunk://#diff-9b03529f8909aa492e1459d80fb3e822510ad1f6ac41a8c51bd021a2af8f3fc9L64-L65) [[3]](diffhunk://#diff-9b03529f8909aa492e1459d80fb3e822510ad1f6ac41a8c51bd021a2af8f3fc9L78-R91)

### Frontend styling:
* **Pinned address styling**: Added a "📍" emoji for pinned addresses in the CSS. (`assets/css/styles.css`, [assets/css/styles.cssR497-R501](diffhunk://#diff-447f1d1a72b4c07f78281064a4d160950b50b5af2552302b3aec4e28181534abR497-R501))

### Testing improvements:
* **New postal address fixture**: Introduced `PostalAddressPageFixture` to facilitate testing of postal address rendering. (`tests/fixtures/postal-address.ts`, [tests/fixtures/postal-address.tsR1-R114](diffhunk://#diff-2f30923b10fc97717483c5453a24eb495fb33265f09609ad09bead1027f665afR1-R114))
* **Integration tests**: Added comprehensive Playwright tests to validate postal address rendering, including scenarios for missing fields and Google Maps links. (`tests/postal-address.test.ts`, [tests/postal-address.test.tsR1-R200](diffhunk://#diff-60fa416f9c740b759db644d095e6535ac6d7f4fd17bf9dd8a6ddb88559343220R1-R200))
* **Fixture updates**: Extended `TestFixtures` to include `postalAddressPage` for testing postal address functionality. (`tests/fixtures.ts`, [[1]](diffhunk://#diff-d4557b0220a5549eb060896e7c01cf57477cc3d345296698c1a3e8b7f3d8d58dL8-R9) [[2]](diffhunk://#diff-d4557b0220a5549eb060896e7c01cf57477cc3d345296698c1a3e8b7f3d8d58dR47) [[3]](diffhunk://#diff-d4557b0220a5549eb060896e7c01cf57477cc3d345296698c1a3e8b7f3d8d58dR78-R82)

### Dependency updates:
* **New dependencies**: Added `json-to-pretty-yaml` and its types to support YAML generation for tests. (`package.json`, [package.jsonL12-R15](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L12-R15))